### PR TITLE
Make NewSparseMerkleTree() handle an empty map of leaves same as nil

### DIFF
--- a/sparse_merkle_tree.go
+++ b/sparse_merkle_tree.go
@@ -280,7 +280,7 @@ func NewSparseMerkleTree(depth int64, leaves map[uint64][]byte) (*SparseMerkleTr
 	smt := &SparseMerkleTree{depth, sortedLeaves, nil, nil, nil}
 	smt.defaultNodes = smt.CreateDefaultNodes(smt.depth)
 
-	if leaves != nil {
+	if len(leaves) != 0 {
 		smt.tree = smt.CreateTree(smt.leaves, smt.depth, smt.defaultNodes)
 		root, ok := smt.tree[len(smt.tree)-1].Get(uint64(0))
 		if !ok {

--- a/sparse_merkle_tree_test.go
+++ b/sparse_merkle_tree_test.go
@@ -60,8 +60,14 @@ func TestSizeLimits2(t *testing.T) {
 }
 
 func TestSMTEmptySMT(t *testing.T) {
-	emptyTree, _ := NewSparseMerkleTree(64, nil)
-	require.Equal(t, 0, emptyTree.leaves.Len())
+	emptyTree1, _ := NewSparseMerkleTree(64, nil)
+	emptyTree2, _ := NewSparseMerkleTree(64, map[uint64][]byte{})
+	for _, emptyTree := range []*SparseMerkleTree{emptyTree1, emptyTree2} {
+		require.Equal(t, 0, emptyTree.leaves.Len())
+		require.Equal(t,
+			"6f35419d1da1260bc0f33d52e8f6d73fc5d672c0dca13bb960b4ae1adec17937",
+			hex.EncodeToString(emptyTree.root))
+	}
 }
 
 func TestSMTAllLeavesWithVal(t *testing.T) {


### PR DESCRIPTION
Previously passing in an empty map of leaves resulted in the function erroring out with "root not found". No real reason to treat an empty map of leaves any different to a nil one though.